### PR TITLE
packaged & installable via pip + added logic to allow alt json-infile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+#*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# PyCharm
+.idea/
+
+# IPython Notebooks (FOR NOW)
+*.ipynb
+.ipynb_checkpoints/
+
+
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+
+# Scratchfiles
+scratch/
+Scratch/
+scratch.py
+Scratch.py
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE
+include automationassets/localassets.json
+include images/*.png

--- a/automationassets/__init__.py
+++ b/automationassets/__init__.py
@@ -1,0 +1,5 @@
+from .automationassets import get_automation_variable
+from .automationassets import set_automation_variable
+from .automationassets import get_automation_credential
+from .automationassets import get_automation_connection
+from .automationassets import get_automation_certificate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyopenssl

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="automationassets",
+    version="0.0.1",
+    description="Enables the development and testing of Azure Automation python runbooks in an offline experience using the built-in Automation assets (variables, credentials, connections, and certificates).",
+    url="https://azure.microsoft.com/en-us/services/automation/",
+    author="Eamon O'Reilly @ Microsoft",
+    license="MIT",
+
+    packages=find_packages(),
+    package_data={'automationassets' : ['localassets.json']},
+    include_package_data=True,
+
+    install_requires=[
+        'pyopenssl',
+    ],
+    zipsafe=False,
+)


### PR DESCRIPTION
## Packaging changes:

- Added a `requirements.txt` & made a `setup.py` file that'll keep the `localassets.json` accessible when using `pip install .` after downloading the repo & modifying `localassets.json`.   

_(Consequently, I'd still suggest **NOT** allowing downloads via pypi, otherwise that **default** JSON file will end up in the users `/blah/blah/lib/(site-packages|pythonX.Y)/automationassets/` dir.)_

- Added a `MANIFEST.in` file that'll do the same if an OS-conflict arises in `setup.py`'s `find_packages()` black-magic demon-function. 

## Allowance of alternative json-infile

- Because this is now `pip` installable, saving the JSON file with your credentials, app-id, and cert-info into your python library may not be the best option. I added `alt_infile=None` kwargs to `_get_asset()` and `alt_outfile=None` to `_set_asset()`

### Notes:
- Make sure the `setup.py` license/author/etc... info looks good! I just filled out what I thought was right.